### PR TITLE
Fix null error on cold start

### DIFF
--- a/client/src/components/Experience.jsx
+++ b/client/src/components/Experience.jsx
@@ -12,7 +12,7 @@ export const Experience = () => {
   const [buildMode, setBuildMode] = useAtom(buildModeAtom);
   const [characters] = useAtom(charactersAtom);
   const [map] = useAtom(mapAtom);
-  const [items, setItems] = useState(map.items);
+  const [items, setItems] = useState(map.items ?? []);
   const [onFloor, setOnFloor] = useState(false);
   useCursor(onFloor);
   const { vector3ToGrid, gridToVector3 } = useGrid();


### PR DESCRIPTION
## Before

When trying to connect to the server for the first time, the client get an error about the `items` atom being undefined.

## Changes

Initialize the items as an empty array for the first user connection.
